### PR TITLE
Update nav and images

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,15 +5,48 @@
   <link rel="stylesheet" href="https://cdn.tailwindcss.com?plugins=forms,container-queries">
 </head>
 <body class="bg-[#111a22] text-white" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
-  <header class="border-b border-[#233648] px-10 py-3 flex items-center justify-between">
-    <div class="flex items-center gap-4">
-      <span class="font-bold text-lg">QWER</span>
-      <nav class="flex gap-6">
-        <a href="index.html">ホーム</a>
-        <a href="explore.html">探索</a>
-        <a href="discover.html">発見</a>
-        <a href="about.html">概要</a>
-      </nav>
+  <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#233648] px-10 py-3">
+    <div class="flex items-center gap-4 text-white">
+      <div class="size-4">
+        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+      </div>
+      <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">QWER</h2>
+    </div>
+    <div class="flex flex-1 justify-end gap-8">
+      <div class="flex items-center gap-9">
+        <a class="text-white text-sm font-medium leading-normal" href="./index.html">ホーム</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./explore.html">探索</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./discover.html">発見</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./about.html">概要</a>
+      </div>
+      <div class="flex gap-2">
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="Bookmark" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M184,32H72A16,16,0,0,0,56,48V224a8,8,0,0,0,12.24,6.78L128,193.43l59.77,37.35A8,8,0,0,0,200,224V48A16,16,0,0,0,184,32Zm0,16V161.57l-51.77-32.35a8,8,0,0,0-8.48,0L72,161.56V48ZM132.23,177.22a8,8,0,0,0-8.48,0L72,209.57V180.43l56-35,56,35v29.14Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div
+        class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+        style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBgdd8SPs9px32OFUbih5ol9-e0__5yqnamlkVR7iGhYNHevGUfIusGOpYYRU_iRemdNgT5s7X3ZQQ2zXbdYLbOsP-cuVlh1rFcffGQeCZnwe5tyKVOQVSHGVS6yiMFWCiLDA5m-SRXPA2nRQoSjS4LbPjitY6Fq-XPKHDx_OAgDVX3x1qAVpKlDJScvcnlj42QbkZiSu0wV0UzRSxtsb0l6EnHboQX3k2hkH1OhOhSdom1gJYpdM9cS-pDE56yqiWJ1gvTQkGbJ6I8");'
+      ></div>
     </div>
   </header>
   <main class="container mx-auto px-4 py-10">

--- a/discover.html
+++ b/discover.html
@@ -71,7 +71,7 @@
                 <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
                   <div
                     class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-xl flex flex-col"
-                    style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBMsuLsAIjaGZMn1TCWzyAmf3r8Aar5jgGuuPdjaZf5rzycj3ZYSx6T92s8K_ihNVwG4eN2JgYQIBmtX8yGEUaqxcoD4Nes79rf");'
+                    style='background-image: url("https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=960&q=80");'
                   ></div>
                   <div>
                     <p class="text-white text-base font-medium leading-normal">未来のプログラムアイデア</p>
@@ -81,7 +81,7 @@
                 <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
                   <div
                     class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-xl flex flex-col"
-                    style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCZTK7rPrLAJ5JTyyHDhQiqM9Cup4Mq507U9-ZCtyQVjZWOlAsCm5hGAEaSf2hoqHXiZMEAcEfYKd_vOxecvKMsZ4Vxmx18B8ca");'
+                    style='background-image: url("https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=960&q=80");'
                   ></div>
                   <div>
                     <p class="text-white text-base font-medium leading-normal">他の人とは違う働き方の提案</p>
@@ -96,14 +96,14 @@
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB4YgiGY8pm4rS-I_VJ9d7E2_lVFgY-AY1lg8aBSOqh0cMnGmf6nq2fb6LQFvogAZkqmkTs5desC9VLYHiUUhOxnuVBHNUHiKzu44");'
+                  style='background-image: url("https://images.unsplash.com/photo-1555949963-aa79dcee981d?auto=format&fit=crop&w=500&q=80");'
                 ></div>
                 <p class="text-white text-base font-medium leading-normal">プログラミング</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuC0xV4zQ1Edtn8yE7nUObgTn3aN8jtnxLpKWgFd6X0LHX_-tflPKNSujHPEomqiG9d-y2Hkq_2wc7MYlfPsUt88U7nh21gTIaUpci");'
+                  style='background-image: url("https://images.unsplash.com/photo-1472289065668-ce650ac443d2?auto=format&fit=crop&w=500&q=80");'
                 ></div>
                 <p class="text-white text-base font-medium leading-normal">他の人とは違う働き方</p>
               </div>

--- a/explore.html
+++ b/explore.html
@@ -14,24 +14,51 @@
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-[#111a22] dark group/design-root overflow-x-hidden" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
-        <!-- ヘッダーここから（index.htmlと同じ） -->
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#233648] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
-            <div class="size-4">
-              <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+          <!-- ヘッダーここから（index.htmlと同じ） -->
+          <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#233648] px-10 py-3">
+            <div class="flex items-center gap-4 text-white">
+              <div class="size-4">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+              </div>
+              <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">QWER</h2>
             </div>
-            <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">QWER</h2>
-          </div>
-          <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="./index.html">ホーム</a>
-              <a class="text-white text-sm font-medium leading-normal underline" href="./explore.html">探索</a>
-              <a class="text-white text-sm font-medium leading-normal" href="./discover.html">発見</a>
-              <a class="text-white text-sm font-medium leading-normal" href="./about.html">概要</a>
+            <div class="flex flex-1 justify-end gap-8">
+              <div class="flex items-center gap-9">
+                <a class="text-white text-sm font-medium leading-normal" href="./index.html">ホーム</a>
+                <a class="text-white text-sm font-medium leading-normal" href="./explore.html">探索</a>
+                <a class="text-white text-sm font-medium leading-normal" href="./discover.html">発見</a>
+                <a class="text-white text-sm font-medium leading-normal" href="./about.html">概要</a>
+              </div>
+              <div class="flex gap-2">
+                <button
+                  class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+                >
+                  <div class="text-white" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+                      <path
+                        d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+                      ></path>
+                    </svg>
+                  </div>
+                </button>
+                <button
+                  class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+                >
+                  <div class="text-white" data-icon="Bookmark" data-size="20px" data-weight="regular">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+                      <path
+                        d="M184,32H72A16,16,0,0,0,56,48V224a8,8,0,0,0,12.24,6.78L128,193.43l59.77,37.35A8,8,0,0,0,200,224V48A16,16,0,0,0,184,32Zm0,16V161.57l-51.77-32.35a8,8,0,0,0-8.48,0L72,161.56V48ZM132.23,177.22a8,8,0,0,0-8.48,0L72,209.57V180.43l56-35,56,35v29.14Z"
+                      ></path>
+                    </svg>
+                  </div>
+                </button>
+              </div>
+              <div
+                class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBgdd8SPs9px32OFUbih5ol9-e0__5yqnamlkVR7iGhYNHevGUfIusGOpYYRU_iRemdNgT5s7X3ZQQ2zXbdYLbOsP-cuVlh1rFcffGQeCZnwe5tyKVOQVSHGVS6yiMFWCiLDA5m-SRXPA2nRQoSjS4LbPjitY6Fq-XPKHDx_OAgDVX3x1qAVpKlDJScvcnlj42QbkZiSu0wV0UzRSxtsb0l6EnHboQX3k2hkH1OhOhSdom1gJYpdM9cS-pDE56yqiWJ1gvTQkGbJ6I8");'
+              ></div>
             </div>
-            <!-- 検索やブックマーク等のボタン部分はお好みでコピペ -->
-          </div>
-        </header>
+          </header>
         <!-- ヘッダーここまで -->
 
         <!-- メインコンテンツここから -->

--- a/index.html
+++ b/index.html
@@ -78,11 +78,12 @@
                       QWERとともに探索の旅に出ましょう. 最先端のテクノロジーを探索し、革新的なアイデアを発見し、テクノロジーエンジニアのコミュニティと情報を共有しましょう.
                     </h2>
                   </div>
-                  <button
+                  <a
+                    href="./explore.html"
                     class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#2a8bed] text-white text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
                   >
                     <span class="truncate">探索を開始</span>
-                  </button>
+                  </a>
                 </div>
               </div>
             </div>

--- a/privacy.html
+++ b/privacy.html
@@ -5,15 +5,48 @@
   <link rel="stylesheet" href="https://cdn.tailwindcss.com?plugins=forms,container-queries">
 </head>
 <body class="bg-[#111a22] text-white" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
-  <header class="border-b border-[#233648] px-10 py-3 flex items-center justify-between">
-    <div class="flex items-center gap-4">
-      <span class="font-bold text-lg">QWER</span>
-      <nav class="flex gap-6">
-        <a href="index.html">ホーム</a>
-        <a href="explore.html">探索</a>
-        <a href="discover.html">発見</a>
-        <a href="about.html">概要</a>
-      </nav>
+  <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#233648] px-10 py-3">
+    <div class="flex items-center gap-4 text-white">
+      <div class="size-4">
+        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+      </div>
+      <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">QWER</h2>
+    </div>
+    <div class="flex flex-1 justify-end gap-8">
+      <div class="flex items-center gap-9">
+        <a class="text-white text-sm font-medium leading-normal" href="./index.html">ホーム</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./explore.html">探索</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./discover.html">発見</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./about.html">概要</a>
+      </div>
+      <div class="flex gap-2">
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="Bookmark" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M184,32H72A16,16,0,0,0,56,48V224a8,8,0,0,0,12.24,6.78L128,193.43l59.77,37.35A8,8,0,0,0,200,224V48A16,16,0,0,0,184,32Zm0,16V161.57l-51.77-32.35a8,8,0,0,0-8.48,0L72,161.56V48ZM132.23,177.22a8,8,0,0,0-8.48,0L72,209.57V180.43l56-35,56,35v29.14Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div
+        class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+        style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBgdd8SPs9px32OFUbih5ol9-e0__5yqnamlkVR7iGhYNHevGUfIusGOpYYRU_iRemdNgT5s7X3ZQQ2zXbdYLbOsP-cuVlh1rFcffGQeCZnwe5tyKVOQVSHGVS6yiMFWCiLDA5m-SRXPA2nRQoSjS4LbPjitY6Fq-XPKHDx_OAgDVX3x1qAVpKlDJScvcnlj42QbkZiSu0wV0UzRSxtsb0l6EnHboQX3k2hkH1OhOhSdom1gJYpdM9cS-pDE56yqiWJ1gvTQkGbJ6I8");'
+      ></div>
     </div>
   </header>
   <main class="container mx-auto px-4 py-10">

--- a/terms.html
+++ b/terms.html
@@ -5,15 +5,48 @@
   <link rel="stylesheet" href="https://cdn.tailwindcss.com?plugins=forms,container-queries">
 </head>
 <body class="bg-[#111a22] text-white" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
-  <header class="border-b border-[#233648] px-10 py-3 flex items-center justify-between">
-    <div class="flex items-center gap-4">
-      <span class="font-bold text-lg">QWER</span>
-      <nav class="flex gap-6">
-        <a href="index.html">ホーム</a>
-        <a href="explore.html">探索</a>
-        <a href="discover.html">発見</a>
-        <a href="about.html">概要</a>
-      </nav>
+  <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#233648] px-10 py-3">
+    <div class="flex items-center gap-4 text-white">
+      <div class="size-4">
+        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+      </div>
+      <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">QWER</h2>
+    </div>
+    <div class="flex flex-1 justify-end gap-8">
+      <div class="flex items-center gap-9">
+        <a class="text-white text-sm font-medium leading-normal" href="./index.html">ホーム</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./explore.html">探索</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./discover.html">発見</a>
+        <a class="text-white text-sm font-medium leading-normal" href="./about.html">概要</a>
+      </div>
+      <div class="flex gap-2">
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+        <button
+          class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 bg-[#233648] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+        >
+          <div class="text-white" data-icon="Bookmark" data-size="20px" data-weight="regular">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+              <path
+                d="M184,32H72A16,16,0,0,0,56,48V224a8,8,0,0,0,12.24,6.78L128,193.43l59.77,37.35A8,8,0,0,0,200,224V48A16,16,0,0,0,184,32Zm0,16V161.57l-51.77-32.35a8,8,0,0,0-8.48,0L72,161.56V48ZM132.23,177.22a8,8,0,0,0-8.48,0L72,209.57V180.43l56-35,56,35v29.14Z"
+              ></path>
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div
+        class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+        style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBgdd8SPs9px32OFUbih5ol9-e0__5yqnamlkVR7iGhYNHevGUfIusGOpYYRU_iRemdNgT5s7X3ZQQ2zXbdYLbOsP-cuVlh1rFcffGQeCZnwe5tyKVOQVSHGVS6yiMFWCiLDA5m-SRXPA2nRQoSjS4LbPjitY6Fq-XPKHDx_OAgDVX3x1qAVpKlDJScvcnlj42QbkZiSu0wV0UzRSxtsb0l6EnHboQX3k2hkH1OhOhSdom1gJYpdM9cS-pDE56yqiWJ1gvTQkGbJ6I8");'
+      ></div>
     </div>
   </header>
   <main class="container mx-auto px-4 py-10">


### PR DESCRIPTION
## Summary
- link Explore button on home page
- unify navigation headers across pages
- add missing search/bookmark icons to Explore and simple pages
- fill Discover page images with Unsplash placeholders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684befbf3734832ba19cc7f87587a566