### PR TITLE
Normalize crossorigin attribute

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
     <link
       rel="stylesheet"
       as="style"

--- a/explore.html
+++ b/explore.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
     <link
       rel="stylesheet"
       as="style"

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
     <link
       rel="stylesheet"
       as="style"


### PR DESCRIPTION
## Summary
- fix inconsistent `crossorigin` usage in `link rel="preconnect"` tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686409ddf770832b91b0dde0452f7d43